### PR TITLE
Make the code state its contracts: type hints, session scoping, and typed failures

### DIFF
--- a/Cloth Shop Website/Web/config.py
+++ b/Cloth Shop Website/Web/config.py
@@ -5,7 +5,7 @@ import secrets
 SECRET_KEY_VARIABLES = ('SECRET_KEY', 'SECRET_KEY_CLOTH_SHOP')
 
 
-def secret_key_from_environment():
+def secret_key_from_environment() -> str | None:
     for variable in SECRET_KEY_VARIABLES:
         key = os.environ.get(variable)
         if key:
@@ -24,7 +24,7 @@ class Config:
     HOST = '127.0.0.1'
     PORT = 5000
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.SECRET_KEY = secret_key_from_environment() or secrets.token_hex(32)
 
 
@@ -41,7 +41,7 @@ class TestingConfig(Config):
 class ProductionConfig(Config):
     HOST = '0.0.0.0'
 
-    def __init__(self):
+    def __init__(self) -> None:
         key = secret_key_from_environment()
         if not key:
             raise RuntimeError(
@@ -63,7 +63,7 @@ CONFIGURATIONS = {
 DEFAULT_ENVIRONMENT = 'development'
 
 
-def get_config(environment=None):
+def get_config(environment: str | None = None) -> Config:
     name = (environment or os.environ.get('APP_ENV') or DEFAULT_ENVIRONMENT).strip().lower()
     try:
         configuration = CONFIGURATIONS[name]

--- a/Cloth Shop Website/Web/create_database.py
+++ b/Cloth Shop Website/Web/create_database.py
@@ -1,5 +1,6 @@
+from typing import Any
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session as SQLSession, sessionmaker
 from models import User, Product, Rating, Base
 import json
 
@@ -12,7 +13,7 @@ Session = sessionmaker(bind=engine)
 
 
 # Function to load data from a JSON file
-def load_data_from_json(filename):
+def load_data_from_json(filename: str) -> dict[str, Any] | None:
     try:
         with open(filename, 'r') as json_file:
             data = json.load(json_file)
@@ -21,7 +22,7 @@ def load_data_from_json(filename):
         return None
     
 
-def insert_data_to_database(Session):
+def insert_data_to_database(Session: sessionmaker[SQLSession]) -> None:
     session = Session()
 
 

--- a/Cloth Shop Website/Web/database.py
+++ b/Cloth Shop Website/Web/database.py
@@ -64,61 +64,48 @@ def update_user(
     country: str = "",
     city: str = "",
 ) -> User | None:
-    session = Session()
     user = next((user for user in users if user.id == id), None)
-    if user is not None:
-        user.name = name
-        user.set_password(password)
-        user.email = email
-        user.surname = surname
-        user.phone = phone_number
-        user.country = country
-        user.city = city
+    if user is None:
+        return None
+
+    user.name = name
+    user.set_password(password)
+    user.email = email
+    user.surname = surname
+    user.phone = phone_number
+    user.country = country
+    user.city = city
+    with session_scope(Session) as session:
         session.merge(user)
-        session.commit()
-        session.close()
     return user
 
 
 def get_users(Session: SessionFactory) -> list[User]:
-    session = Session()
-    users = session.query(User).all()
-    session.close()
-    return users
+    with session_scope(Session) as session:
+        return session.query(User).all()
 
 
 def get_user(Session: SessionFactory, user_id: int) -> User | None:
-    session = Session()
-    user = session.query(User).filter(User.id == user_id).first()
-    session.close()
-    return user
+    with session_scope(Session) as session:
+        return session.query(User).filter(User.id == user_id).first()
     
 
 
 def get_products_to_dict(Session: SessionFactory) -> list[ProductDict]:
-    session = Session()
-    results = session.query(Product).all()
-    products = [{'id': r.id, 'name': r.name, 'cost': r.cost, 'cloth_cathegory': r.cloth_cathegory,
+    with session_scope(Session) as session:
+        results = session.query(Product).all()
+        return [{'id': r.id, 'name': r.name, 'cost': r.cost, 'cloth_cathegory': r.cloth_cathegory,
                  'gender': r.gender, 'image': r.image, 'url': r.to_url()} for r in results]
-    session.close()
-    return products
 
 def get_product(Session: SessionFactory, product_id: int) -> Product | None:
-    session = Session()
-    result = session.query(Product).filter(Product.id == product_id).first()
-    session.close()
-
-    if result:
-        return result
-    else:
-        return None
+    with session_scope(Session) as session:
+        return session.query(Product).filter(Product.id == product_id).first()
 
 
 def modify_rating(session: Session, rating_obj: Rating, rating_points: float) -> Rating:
     rating_obj.rating_points = rating_points
     session.merge(rating_obj)
     session.commit()
-    session.close()
     return rating_obj
 
 
@@ -149,35 +136,26 @@ def create_rating(
 
 
 def get_ratings(Session: SessionFactory) -> list[Rating]:
-    session = Session()
-    results = session.query(Rating).all()
-    session.close()
-    return results
+    with session_scope(Session) as session:
+        return session.query(Rating).all()
 
 def get_certain_rating(Session: SessionFactory, product_id: int, user_id: int) -> Rating | None:
-    session = Session()
-    rating = session.query(Rating).filter_by(product_id=product_id, user_id=user_id).first()
-    session.close()
-    return rating
+    with session_scope(Session) as session:
+        return session.query(Rating).filter_by(product_id=product_id, user_id=user_id).first()
 
 def get_all_ratings_of_a_product(Session: SessionFactory, product_id: int) -> tuple[list[Rating], int]:
-    session = Session()
-    ratings = session.query(Rating).filter_by(product_id=product_id).all()
-    session.close()
-    return ratings, len(ratings)
+    with session_scope(Session) as session:
+        ratings = session.query(Rating).filter_by(product_id=product_id).all()
+        return ratings, len(ratings)
 
 def remove_rating(Session: SessionFactory, product_id: int, user_id: int) -> bool:
-    session = Session()
-    rating = session.query(Rating).filter_by(product_id=product_id, user_id=user_id).first()
+    with session_scope(Session) as session:
+        rating = session.query(Rating).filter_by(product_id=product_id, user_id=user_id).first()
+        if rating is None:
+            return False
 
-    if rating:
         session.delete(rating)
-        session.commit()
-        session.close()
-        return True  
-    else:
-        session.close()
-        return False  
+        return True
     
     
 
@@ -211,32 +189,24 @@ def format_review_dates(reviews: list[Review]) -> list[Review]:
     return reviews
     
 def get_reviews_of_a_product(Session: SessionFactory, product_id: int) -> list[Review]:
-    session = Session()
-    reviews = session.query(Review).filter_by(product_id=product_id).all()
-    session.close()
-    reviews = format_review_dates(reviews)
-    return reviews
+    with session_scope(Session) as session:
+        reviews = session.query(Review).filter_by(product_id=product_id).all()
+    return format_review_dates(reviews)
 
 def get_all_reviews(Session: SessionFactory) -> list[Review]:
-    session = Session()
-    reviews = session.query(Review).all()
-    session.close()
-    return reviews
+    with session_scope(Session) as session:
+        return session.query(Review).all()
 
 
 
 def remove_review(Session: SessionFactory, review_id: int, user_id: int) -> bool:
-    session = Session()
-    review = session.query(Review).filter_by(id=review_id, user_id=user_id).first()
+    with session_scope(Session) as session:
+        review = session.query(Review).filter_by(id=review_id, user_id=user_id).first()
+        if review is None:
+            return False
 
-    if review:
         session.delete(review)
-        session.commit()
-        session.close()
-        return True  
-    else:
-        session.close()
-        return False  
+        return True
 
     
 

--- a/Cloth Shop Website/Web/database.py
+++ b/Cloth Shop Website/Web/database.py
@@ -1,9 +1,13 @@
 from contextlib import contextmanager
+from typing import Any, Iterator
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 from datetime import datetime
 from models import User, Product, Rating, Review ,Base
+
+SessionFactory = sessionmaker[Session]
+ProductDict = dict[str, Any]
 
 
 UNIQUE_INDEXES = (
@@ -14,7 +18,7 @@ UNIQUE_INDEXES = (
 )
 
 
-def create_database_Session(url):
+def create_database_Session(url: str) -> SessionFactory:
     engine = create_engine(url, echo=True)
     Base.metadata.create_all(bind=engine)
     with engine.begin() as connection:
@@ -25,7 +29,7 @@ def create_database_Session(url):
 
 
 @contextmanager
-def session_scope(Session):
+def session_scope(Session: SessionFactory) -> Iterator[Session]:
     session = Session()
     try:
         yield session
@@ -37,7 +41,7 @@ def session_scope(Session):
         session.close()
 
 
-def create_user(Session, name, password, email):
+def create_user(Session: SessionFactory, name: str, password: str, email: str) -> User | None:
     with session_scope(Session) as session:
         user = User(name=name, password=password, email=email)
         session.add(user)
@@ -48,7 +52,18 @@ def create_user(Session, name, password, email):
             return None
     return user
 
-def update_user(Session, id, name, password, email, users, surname="", phone_number="", country="", city=""):
+def update_user(
+    Session: SessionFactory,
+    id: int,
+    name: str,
+    password: str,
+    email: str,
+    users: list[User],
+    surname: str = "",
+    phone_number: str = "",
+    country: str = "",
+    city: str = "",
+) -> User | None:
     session = Session()
     user = next((user for user in users if user.id == id), None)
     if user is not None:
@@ -65,14 +80,14 @@ def update_user(Session, id, name, password, email, users, surname="", phone_num
     return user
 
 
-def get_users(Session):
+def get_users(Session: SessionFactory) -> list[User]:
     session = Session()
     users = session.query(User).all()
     session.close()
     return users
 
 
-def get_user(Session, user_id):
+def get_user(Session: SessionFactory, user_id: int) -> User | None:
     session = Session()
     user = session.query(User).filter(User.id == user_id).first()
     session.close()
@@ -80,7 +95,7 @@ def get_user(Session, user_id):
     
 
 
-def get_products_to_dict(Session):
+def get_products_to_dict(Session: SessionFactory) -> list[ProductDict]:
     session = Session()
     results = session.query(Product).all()
     products = [{'id': r.id, 'name': r.name, 'cost': r.cost, 'cloth_cathegory': r.cloth_cathegory,
@@ -88,7 +103,7 @@ def get_products_to_dict(Session):
     session.close()
     return products
 
-def get_product(Session, product_id):
+def get_product(Session: SessionFactory, product_id: int) -> Product | None:
     session = Session()
     result = session.query(Product).filter(Product.id == product_id).first()
     session.close()
@@ -99,7 +114,7 @@ def get_product(Session, product_id):
         return None
 
 
-def modify_rating(session, rating_obj, rating_points):
+def modify_rating(session: Session, rating_obj: Rating, rating_points: float) -> Rating:
     rating_obj.rating_points = rating_points
     session.merge(rating_obj)
     session.commit()
@@ -107,7 +122,12 @@ def modify_rating(session, rating_obj, rating_points):
     return rating_obj
 
 
-def create_rating(Session, product_id, user_id, new_rating_points):
+def create_rating(
+    Session: SessionFactory,
+    product_id: int,
+    user_id: int,
+    new_rating_points: float,
+) -> Rating | str:
     with session_scope(Session) as session:
         if not session.get(User, user_id) or not session.get(Product, product_id):
             return 'Could not find this product or this user'
@@ -128,25 +148,25 @@ def create_rating(Session, product_id, user_id, new_rating_points):
         return rating_obj
 
 
-def get_ratings(Session):
+def get_ratings(Session: SessionFactory) -> list[Rating]:
     session = Session()
     results = session.query(Rating).all()
     session.close()
     return results
 
-def get_certain_rating(Session, product_id, user_id):
+def get_certain_rating(Session: SessionFactory, product_id: int, user_id: int) -> Rating | None:
     session = Session()
     rating = session.query(Rating).filter_by(product_id=product_id, user_id=user_id).first()
     session.close()
     return rating
 
-def get_all_ratings_of_a_product(Session, product_id):
+def get_all_ratings_of_a_product(Session: SessionFactory, product_id: int) -> tuple[list[Rating], int]:
     session = Session()
     ratings = session.query(Rating).filter_by(product_id=product_id).all()
     session.close()
     return ratings, len(ratings)
 
-def remove_rating(Session, product_id, user_id):
+def remove_rating(Session: SessionFactory, product_id: int, user_id: int) -> bool:
     session = Session()
     rating = session.query(Rating).filter_by(product_id=product_id, user_id=user_id).first()
 
@@ -161,7 +181,12 @@ def remove_rating(Session, product_id, user_id):
     
     
 
-def create_review(Session, product_id, user_id, review_content):
+def create_review(
+    Session: SessionFactory,
+    product_id: int,
+    user_id: int,
+    review_content: str,
+) -> Review | None | bool:
     with session_scope(Session) as session:
         if not session.get(User, user_id) or not session.get(Product, product_id):
             return None
@@ -175,7 +200,7 @@ def create_review(Session, product_id, user_id, review_content):
             return False
         return review_object
     
-def format_review_dates(reviews):
+def format_review_dates(reviews: list[Review]) -> list[Review]:
     
     for review in reviews:
         date_object = datetime.strptime(str(review.date), '%Y-%m-%d %H:%M:%S.%f')
@@ -185,14 +210,14 @@ def format_review_dates(reviews):
     
     return reviews
     
-def get_reviews_of_a_product(Session, product_id):
+def get_reviews_of_a_product(Session: SessionFactory, product_id: int) -> list[Review]:
     session = Session()
     reviews = session.query(Review).filter_by(product_id=product_id).all()
     session.close()
     reviews = format_review_dates(reviews)
     return reviews
 
-def get_all_reviews(Session):
+def get_all_reviews(Session: SessionFactory) -> list[Review]:
     session = Session()
     reviews = session.query(Review).all()
     session.close()
@@ -200,7 +225,7 @@ def get_all_reviews(Session):
 
 
 
-def remove_review(Session, review_id, user_id):
+def remove_review(Session: SessionFactory, review_id: int, user_id: int) -> bool:
     session = Session()
     review = session.query(Review).filter_by(id=review_id, user_id=user_id).first()
 

--- a/Cloth Shop Website/Web/database.py
+++ b/Cloth Shop Website/Web/database.py
@@ -5,6 +5,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 from datetime import datetime
 from models import User, Product, Rating, Review ,Base
+from exceptions import DuplicateReview, DuplicateUser, ProductNotFound, UserNotFound
 
 SessionFactory = sessionmaker[Session]
 ProductDict = dict[str, Any]
@@ -41,15 +42,15 @@ def session_scope(Session: SessionFactory) -> Iterator[Session]:
         session.close()
 
 
-def create_user(Session: SessionFactory, name: str, password: str, email: str) -> User | None:
+def create_user(Session: SessionFactory, name: str, password: str, email: str) -> User:
     with session_scope(Session) as session:
         user = User(name=name, password=password, email=email)
         session.add(user)
         try:
             session.flush()
-        except IntegrityError:
+        except IntegrityError as exc:
             session.rollback()
-            return None
+            raise DuplicateUser(name, email) from exc
     return user
 
 def update_user(
@@ -63,10 +64,10 @@ def update_user(
     phone_number: str = "",
     country: str = "",
     city: str = "",
-) -> User | None:
+) -> User:
     user = next((user for user in users if user.id == id), None)
     if user is None:
-        return None
+        raise UserNotFound(id)
 
     user.name = name
     user.set_password(password)
@@ -114,10 +115,12 @@ def create_rating(
     product_id: int,
     user_id: int,
     new_rating_points: float,
-) -> Rating | str:
+) -> Rating:
     with session_scope(Session) as session:
-        if not session.get(User, user_id) or not session.get(Product, product_id):
-            return 'Could not find this product or this user'
+        if not session.get(User, user_id):
+            raise UserNotFound(user_id)
+        if not session.get(Product, product_id):
+            raise ProductNotFound(product_id)
 
         rating_obj = session.query(Rating).filter_by(product_id=product_id, user_id=user_id).first()
         if rating_obj is None:
@@ -164,18 +167,20 @@ def create_review(
     product_id: int,
     user_id: int,
     review_content: str,
-) -> Review | None | bool:
+) -> Review:
     with session_scope(Session) as session:
-        if not session.get(User, user_id) or not session.get(Product, product_id):
-            return None
+        if not session.get(User, user_id):
+            raise UserNotFound(user_id)
+        if not session.get(Product, product_id):
+            raise ProductNotFound(product_id)
 
         review_object = Review(product_id=product_id, user_id=user_id, content=review_content)
         session.add(review_object)
         try:
             session.flush()
-        except IntegrityError:
+        except IntegrityError as exc:
             session.rollback()
-            return False
+            raise DuplicateReview(product_id, user_id) from exc
         return review_object
     
 def format_review_dates(reviews: list[Review]) -> list[Review]:

--- a/Cloth Shop Website/Web/exceptions.py
+++ b/Cloth Shop Website/Web/exceptions.py
@@ -1,0 +1,28 @@
+class ShopError(Exception):
+    """Base class for failures raised by the data layer."""
+
+
+class ProductNotFound(ShopError):
+    def __init__(self, product_id: int) -> None:
+        super().__init__(f'No product with id {product_id}')
+        self.product_id = product_id
+
+
+class UserNotFound(ShopError):
+    def __init__(self, user_id: int) -> None:
+        super().__init__(f'No user with id {user_id}')
+        self.user_id = user_id
+
+
+class DuplicateUser(ShopError):
+    def __init__(self, name: str, email: str) -> None:
+        super().__init__(f'An account already exists for {name!r} or {email!r}')
+        self.name = name
+        self.email = email
+
+
+class DuplicateReview(ShopError):
+    def __init__(self, product_id: int, user_id: int) -> None:
+        super().__init__(f'User {user_id} has already reviewed product {product_id}')
+        self.product_id = product_id
+        self.user_id = user_id

--- a/Cloth Shop Website/Web/main.py
+++ b/Cloth Shop Website/Web/main.py
@@ -1,13 +1,15 @@
 from flask import Flask, Response, render_template, redirect, url_for, jsonify, request, session
 from flask.typing import ResponseReturnValue
 from config import get_config
+from exceptions import DuplicateReview, DuplicateUser, ProductNotFound, ShopError, UserNotFound
 from utils import (
-    check_if_error,
-    check_login,
+    ValidationError,
+    authenticate,
     filter_products,
     get_genders_and_kinds,
     get_product_by_url,
     get_username_by_id_filter,
+    validate_account,
 )
 from database import (
     create_database_Session,
@@ -34,6 +36,21 @@ db_Session = create_database_Session('sqlite:///Cloth Shop Website/Databases/myd
 products = get_products_to_dict(db_Session)
 
 app.jinja_env.filters['get_username_by_id'] = get_username_by_id_filter
+
+
+def messages_by_field(errors: list[ValidationError]) -> dict[str, str]:
+    return {error.field: error.message for error in errors}
+
+
+@app.errorhandler(DuplicateReview)
+def handle_duplicate_review(error: DuplicateReview) -> ResponseReturnValue:
+    return jsonify({'message': 'You have already reviewed this product'}), 409
+
+
+@app.errorhandler(ProductNotFound)
+@app.errorhandler(UserNotFound)
+def handle_missing_record(error: ShopError) -> ResponseReturnValue:
+    return jsonify({'message': str(error)}), 404
     
 @app.template_filter('nl2br')
 def nl2br_filter(s: str) -> str:
@@ -73,7 +90,7 @@ def my_route() -> ResponseReturnValue:
 
 @app.route('/account', methods = ['POST', 'GET'])
 def account() -> ResponseReturnValue:
-    error = None
+    errors: list[ValidationError] = []
 
     if 'user' not in session:
         return redirect(url_for('login'))
@@ -91,19 +108,17 @@ def account() -> ResponseReturnValue:
 
             users = get_users(db_Session)
 
-            error = check_if_error(users, id, username, email, password)
-            if error is None:
-
+            errors = validate_account(users, id, username, email, password)
+            if not errors:
                 user = update_user(db_Session, id, username, password, email, users, surname, phone_number, country, city)
-                if user is not None:
-                    session['user'] = user.to_dict()
+                session['user'] = user.to_dict()
 
         user_info = session['user']
-        return render_template('account.html', user_info = user_info, error = error)
+        return render_template('account.html', user_info = user_info, errors = messages_by_field(errors))
 
 @app.route('/login', methods = ['POST', 'GET'])
 def login() -> ResponseReturnValue:
-    potential_error = None
+    error = None
     if request.method == 'POST':
 
         if request.form['action'] == "Create account":
@@ -113,20 +128,19 @@ def login() -> ResponseReturnValue:
         password = request.form['password']
 
         users = get_users(db_Session)
-        potential_error, user_info = check_login(username, password, users)
+        user_info, error = authenticate(username, password, users)
 
-
-        if potential_error == 'good':
+        if user_info is not None:
             session['user'] = user_info.to_dict()
             return redirect(url_for('account'))
 
-    return render_template('login.html', error = potential_error)
+    return render_template('login.html', error = error.message if error else None)
 
 
 @app.route('/create_account', methods = ['POST', 'GET'])
 def create_account() -> ResponseReturnValue:
 
-    error = None
+    errors: list[ValidationError] = []
 
     if request.method == 'POST':
         username = request.form['username']
@@ -135,19 +149,18 @@ def create_account() -> ResponseReturnValue:
 
         users = get_users(db_Session)
 
-        error = check_if_error(users, None, username, email, password)
+        errors = validate_account(users, None, username, email, password)
 
-        if error is None:
-            user = create_user(db_Session, username, password, email)
-            if user is None:
-                return render_template('create_account.html', error = 'Already such an User')
-            session['user'] = user.to_dict()
-            return redirect(url_for('account'))
+        if not errors:
+            try:
+                user = create_user(db_Session, username, password, email)
+            except DuplicateUser:
+                errors = [ValidationError('username', 'Already such an User')]
+            else:
+                session['user'] = user.to_dict()
+                return redirect(url_for('account'))
 
-        else:
-            return render_template('create_account.html', error = error)
-
-    return render_template('create_account.html', error = error)
+    return render_template('create_account.html', errors = messages_by_field(errors))
 
 @app.route('/basket', methods = ['GET'])
 def basket() -> ResponseReturnValue:
@@ -236,11 +249,7 @@ def save_review() -> ResponseReturnValue:
     product_id_data = int(data['productId'])
     user_id = session['user']['id']
     review_object = create_review(db_Session, product_id_data, user_id, review_content)
-    if review_object:
-        object_id = review_object.id
-        return jsonify({'message': 'Review saved successfully', 'id': object_id})
-    else:
-        return jsonify({'message': 'error'})
+    return jsonify({'message': 'Review saved successfully', 'id': review_object.id})
 
 @app.route('/delete_review', methods=['POST'])
 def delete_review() -> ResponseReturnValue:

--- a/Cloth Shop Website/Web/main.py
+++ b/Cloth Shop Website/Web/main.py
@@ -1,4 +1,5 @@
-from flask import Flask, render_template, redirect, url_for, jsonify, request, session
+from flask import Flask, Response, render_template, redirect, url_for, jsonify, request, session
+from flask.typing import ResponseReturnValue
 from config import get_config
 from utils import (
     check_if_error,
@@ -35,20 +36,20 @@ products = get_products_to_dict(db_Session)
 app.jinja_env.filters['get_username_by_id'] = get_username_by_id_filter
     
 @app.template_filter('nl2br')
-def nl2br_filter(s):
+def nl2br_filter(s: str) -> str:
     return s.replace('\n', '<br>')
 
 @app.route('/')
-def home():
+def home() -> ResponseReturnValue:
     return render_template('home.html')
 
 @app.route('/cloth')
-def cloth():
+def cloth() -> ResponseReturnValue:
     product_data_json = jsonify(products)
     return render_template('cloth.html', products = products, products_json = product_data_json)
 
 @app.route('/filtered-products', methods=['POST'])
-def get_filtered_products():
+def get_filtered_products() -> ResponseReturnValue:
     min_value = float(request.form['minvalue'])
     max_value = float(request.form['maxvalue'])
 
@@ -63,7 +64,7 @@ def get_filtered_products():
     return jsonify({'products': filtered_products})
 
 @app.route("/add-to-basket", methods=["POST"])
-def my_route():
+def my_route() -> ResponseReturnValue:
     product_ID = int(request.json["product_ID"])
 
     session['basket'].append(product_ID)
@@ -71,7 +72,7 @@ def my_route():
     return "Success"
 
 @app.route('/account', methods = ['POST', 'GET'])
-def account():
+def account() -> ResponseReturnValue:
     error = None
 
     if 'user' not in session:
@@ -101,7 +102,7 @@ def account():
         return render_template('account.html', user_info = user_info, error = error)
 
 @app.route('/login', methods = ['POST', 'GET'])
-def login():
+def login() -> ResponseReturnValue:
     potential_error = None
     if request.method == 'POST':
 
@@ -123,7 +124,7 @@ def login():
 
 
 @app.route('/create_account', methods = ['POST', 'GET'])
-def create_account():
+def create_account() -> ResponseReturnValue:
 
     error = None
 
@@ -149,14 +150,14 @@ def create_account():
     return render_template('create_account.html', error = error)
 
 @app.route('/basket', methods = ['GET'])
-def basket():
+def basket() -> ResponseReturnValue:
     filtered_products = [product for product in products if product['id'] in session['basket']]
     total_cost = sum(product['cost'] for product in filtered_products)
     total_cost = round(total_cost, 2)
     return render_template('basket.html', products = filtered_products, total_cost = total_cost)
 
 @app.route('/basket/<int:product_id>', methods=['DELETE'])
-def delete_product(product_id):
+def delete_product(product_id: int) -> ResponseReturnValue:
     if 'basket' in session:
         basket = session['basket']
         if product_id in basket:
@@ -169,7 +170,7 @@ def delete_product(product_id):
     return jsonify({'success': False, 'message': 'Product not found in the basket'})
 
 @app.route('/checkout')
-def checkout():
+def checkout() -> ResponseReturnValue:
     if session['basket']:
         if 'user' in session:
             user_info = session['user']
@@ -179,7 +180,7 @@ def checkout():
 
 
 @app.route('/cloth/product_detail/<product_url>')
-def product_detail(product_url):
+def product_detail(product_url: str) -> ResponseReturnValue:
 
 
     product_dict = get_product_by_url(products, product_url)
@@ -205,7 +206,7 @@ def product_detail(product_url):
         return render_template('product_not_found.html')
     
 @app.route('/save_rating', methods=['POST'])
-def save_rating():
+def save_rating() -> ResponseReturnValue:
     data = request.get_json()
     rating_data = float(data['rating'])
     product_id_data = int(data['productId'])
@@ -217,7 +218,7 @@ def save_rating():
     return jsonify({'message': 'Rating saved successfully'})
 
 @app.route('/reset_rating', methods=['POST'])
-def reset_rating():
+def reset_rating() -> ResponseReturnValue:
     data = request.get_json()
     product_id_data = int(data['productId'])
     user_id = session['user']['id']
@@ -227,7 +228,7 @@ def reset_rating():
 
 
 @app.route('/save_review', methods=['POST'])
-def save_review():
+def save_review() -> ResponseReturnValue:
     if not 'user' in session:
          return jsonify({'message': 'user not logged in'})
     data = request.get_json()
@@ -242,7 +243,7 @@ def save_review():
         return jsonify({'message': 'error'})
 
 @app.route('/delete_review', methods=['POST'])
-def delete_review():
+def delete_review() -> ResponseReturnValue:
     if not 'user' in session:
          return jsonify({'message': 'user not logged in'})
     else:
@@ -256,7 +257,7 @@ def delete_review():
 
 
 @app.route('/logout')
-def logout():
+def logout() -> ResponseReturnValue | None:
     if 'user' in session:
         session.pop('user', None)
         session['basket'] = []
@@ -266,7 +267,7 @@ def logout():
 
 
 @app.before_request
-def before_request():
+def before_request() -> ResponseReturnValue | None:
     if 'user' in session and request.endpoint in ['login']:
         return redirect(url_for('home'))
     if 'user' in session and request.endpoint in ['create_account']:
@@ -279,7 +280,7 @@ def before_request():
 
 ## User will be unable to go back to a previously visited page and remaining logged in after logging out
 @app.after_request
-def add_header(response):
+def add_header(response: Response) -> Response:
     response.cache_control.no_cache = True
     response.cache_control.no_store = True
     response.cache_control.must_revalidate = True

--- a/Cloth Shop Website/Web/models.py
+++ b/Cloth Shop Website/Web/models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sqlalchemy import Column, String, Integer, Float, DateTime, Index
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import validates
@@ -22,7 +24,17 @@ class User(Base):
     country = Column('country', String)
     city = Column('city', String)
 
-    def __init__(self, name, password, email, surname="", phone="", country="", city="", id=None):
+    def __init__(
+        self,
+        name: str,
+        password: str,
+        email: str,
+        surname: str = "",
+        phone: str = "",
+        country: str = "",
+        city: str = "",
+        id: int | None = None,
+    ) -> None:
         self.id = id
         self.name = name
         self.set_password(password)
@@ -32,17 +44,17 @@ class User(Base):
         self.country = country
         self.city = city
 
-    def set_password(self, password):
+    def set_password(self, password: str) -> None:
         """Hash and store the given plaintext password."""
         self.password_hash = generate_password_hash(password)
 
-    def check_password(self, password):
+    def check_password(self, password: str) -> bool:
         """Return True if the given plaintext password matches the stored hash."""
         if not self.password_hash:
             return False
         return check_password_hash(self.password_hash, password)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {
             'id': self.id,
             'name': self.name,
@@ -53,7 +65,7 @@ class User(Base):
             'city': self.city
         }
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"({self.id}), ({self.name}), ({self.email}), ({self.surname})"
         
     
@@ -67,7 +79,15 @@ class Product(Base):
     gender = Column('gender', String)
     image = Column('image', String)
 
-    def __init__(self, id, name, cost, cloth_cathegory, gender, image):
+    def __init__(
+        self,
+        id: int,
+        name: str,
+        cost: float,
+        cloth_cathegory: str,
+        gender: str,
+        image: str,
+    ) -> None:
         self.id = id
         self.name= name
         self.cost = cost
@@ -76,10 +96,10 @@ class Product(Base):
         self.image = image
         self.url = self.to_url()
 
-    def to_url(self):
+    def to_url(self) -> str:
         return self.name.replace(' ', '-')
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"({self.id})"
     
 
@@ -94,20 +114,26 @@ class Rating(Base):
     user_id = Column('user_id', Integer)
     rating_points = Column('rating_points', Float)
 
-    def __init__(self, product_id, user_id, rating_points, id=None) -> None:
+    def __init__(
+        self,
+        product_id: int,
+        user_id: int,
+        rating_points: float,
+        id: int | None = None,
+    ) -> None:
         self.id = id
         self.product_id = product_id
         self.user_id = user_id
         self.rating_points = rating_points
 
     @validates('rating_points')
-    def validate_rating(self, key, value):
+    def validate_rating(self, key: str, value: float) -> float:
         if not 1 <= value <= 5:
             raise ValueError("Rating must be between 1 and 5 (inclusive)")
         return value
 
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"id ({self.id}), product id({self.product_id}), user id({self.user_id}), rating points ({self.rating_points})"
     
 
@@ -123,13 +149,19 @@ class Review(Base):
     content = Column('content', String)
     date = Column('date', DateTime, default=datetime.datetime.utcnow)
 
-    def __init__(self, product_id, user_id, content, id=None) -> None:
+    def __init__(
+        self,
+        product_id: int,
+        user_id: int,
+        content: str,
+        id: int | None = None,
+    ) -> None:
         self.id = id
         self.product_id = product_id
         self.user_id = user_id
         self.content = content
  
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {
             'id': self.id,
             'product_id': self.product_id,
@@ -139,5 +171,5 @@ class Review(Base):
         }
         
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"id ({self.id}), product id({self.product_id}), user id({self.user_id}), review content ({self.content}), review date ({self.date})"

--- a/Cloth Shop Website/Web/templates/account.html
+++ b/Cloth Shop Website/Web/templates/account.html
@@ -20,22 +20,22 @@
             <form action="#" method="post">
               <label for="username">Username:</label>
               <input type="text" id="username" name="username" value="{{ user_info.name }}">
-                {% if error and 'User' in error %}
-                    <p style="color:red">{{ error }}</p>
+                {% if errors.username %}
+                    <p style="color:red">{{ errors.username }}</p>
                 {% else %}
                     <br><br>
                 {% endif %}
               <label for="email">E-mail:</label>
               <input type="email" id="email" name="email" value="{{ user_info.email }}">
-                {% if error and 'E-mail' in error %}
-                    <p style="color:red">{{ error }}</p>
+                {% if errors.email %}
+                    <p style="color:red">{{ errors.email }}</p>
                 {% else %}
                     <br><br>
                 {% endif %}
               <label for="password">Password:</label>
               <input type="password" id="password" name="password" placeholder="Leave unchanged or enter a new password">
-                {% if error and 'Password' in error %}
-                    <p style="color:red">{{ error }}</p>
+                {% if errors.password %}
+                    <p style="color:red">{{ errors.password }}</p>
                 {% else %}
                     <br><br>
                 {% endif %}

--- a/Cloth Shop Website/Web/templates/create_account.html
+++ b/Cloth Shop Website/Web/templates/create_account.html
@@ -21,21 +21,21 @@
             <form action="#" method="post">
               <label for="username">Username:</label>
               <input type="text" id="username" name="username" value="">
-                {% if error and 'User' in error %}
-                    <p style="color:red">{{ error }}</p>
+                {% if errors.username %}
+                    <p style="color:red">{{ errors.username }}</p>
                 {% else %}
                     <br><br>
                 {% endif %}
               <label for="email">E-mail:</label>
               <input type="email" id="email" name="email" value="">
-                {% if error and 'E-mail' in error %}
-                    <p style="color:red">{{ error }}</p>
+                {% if errors.email %}
+                    <p style="color:red">{{ errors.email }}</p>
                 {% else %}
                     <br><br>
                 {% endif %}
               <label for="password">Password:</label>
-                {% if error and 'password' in error %}
-                    <p style="color:red">{{ error }}</p>
+                {% if errors.password %}
+                    <p style="color:red">{{ errors.password }}</p>
                 {% endif %}
               <input type="password" id="password" name="password" value=""><br><br>
               <input type="submit" value="Submit">

--- a/Cloth Shop Website/Web/tests/test_password_security.py
+++ b/Cloth Shop Website/Web/tests/test_password_security.py
@@ -7,7 +7,7 @@ salted.
 import pytest
 
 from models import User
-from utils import check_login
+from utils import ValidationError, authenticate
 
 
 PLAINTEXT = "correct horse battery"
@@ -83,15 +83,15 @@ def test_repr_exposes_no_credential(user):
     assert PLAINTEXT not in repr(user)
 
 
-def test_check_login_verifies_against_the_hash():
+def test_authenticate_verifies_against_the_hash():
     users = [
         User(id=1, name="john", password="test1", email="john@example.com"),
         User(id=2, name="emma", password="test2", email="emma@example.com"),
     ]
 
-    result, matched = check_login("john", "test1", users)
-    assert result == "good"
+    matched, error = authenticate("john", "test1", users)
+    assert error is None
     assert matched.id == 1
 
-    assert check_login("john", "test2", users)[0] == "Wrong Password"
-    assert check_login("nobody", "test1", users)[0] == "Wrong Username"
+    assert authenticate("john", "test2", users)[1] == ValidationError("password", "Wrong Password")
+    assert authenticate("nobody", "test1", users)[1] == ValidationError("username", "Wrong Username")

--- a/Cloth Shop Website/Web/tests/test_project.py
+++ b/Cloth Shop Website/Web/tests/test_project.py
@@ -13,8 +13,17 @@ from database import (
     update_user,
 )
 from models import User, Product, Rating, Review
+import pytest
 from unittest.mock import patch
-from utils import filter_products, check_login, check_if_error, get_product_by_url, get_genders_and_kinds
+from exceptions import ProductNotFound, UserNotFound
+from utils import (
+    ValidationError,
+    authenticate,
+    filter_products,
+    get_genders_and_kinds,
+    get_product_by_url,
+    validate_account,
+)
 from flask import session
 
 def test_connection_home(client):
@@ -115,7 +124,8 @@ def test_update_user(Session):
     assert db_user1.email == "newemail@example.com"
 
     # Update user 3 (doesn't exist)
-    update_user(Session, 3, "New User", "newpassword", "newemail@example.com", users)
+    with pytest.raises(UserNotFound):
+        update_user(Session, 3, "New User", "newpassword", "newemail@example.com", users)
 
     # Check that user list is still the same
     assert len(users) == 1
@@ -169,8 +179,8 @@ def test_get_ratings(Session):
 
 def test_create_rating(Session):
     rating1 = (1, 3, 1, 3.5) 
-    rating_result = create_rating(Session, rating1[1], rating1[2], rating1[3])
-    assert rating_result == 'Could not find this product or this user'
+    with pytest.raises(ProductNotFound):
+        create_rating(Session, rating1[1], rating1[2], rating1[3])
 
 
     # Add a product  
@@ -395,7 +405,7 @@ def test_filter_products():
     expected_output = []
     assert filtered_products == expected_output
 
-def test_check_login():
+def test_authenticate():
     # Create test users
     users = [
         User(id=1, name="john", password="test1", email="john@example.com"),
@@ -404,24 +414,24 @@ def test_check_login():
     ]
 
     # Test case: Correct username and password
-    result, user = check_login('john', 'test1', users)
-    assert result == 'good'
+    user, error = authenticate('john', 'test1', users)
+    assert error is None
     assert user.id == 1
     assert user.name == "john"
     assert user.check_password("test1")
     assert user.email == "john@example.com"
 
     # Test case: Correct username, wrong password
-    result, user = check_login('emma', 'wrong_password', users)
-    assert result == 'Wrong Password'
+    user, error = authenticate('emma', 'wrong_password', users)
+    assert error == ValidationError('password', 'Wrong Password')
     assert user is None
 
     # Test case: Wrong username
-    result, user = check_login('unknown_user', 'test3', users)
-    assert result == 'Wrong Username'
+    user, error = authenticate('unknown_user', 'test3', users)
+    assert error == ValidationError('username', 'Wrong Username')
     assert user is None
 
-def test_check_if_error():
+def test_validate_account():
     # Create test users
     users = [
         User(id=1, name="john", password="password1", email="john@example.com"),
@@ -429,36 +439,36 @@ def test_check_if_error():
     ]
 
     # Test case 1: Valid inputs, no errors expected
-    result = check_if_error(users, 3, 'Alice', 'alice@example.com', 'password3')
-    assert result is None
+    result = validate_account(users, 3, 'Alice', 'alice@example.com', 'password3')
+    assert result == []
 
     # Test case 2: Empty username, expect 'No Username' error
-    result = check_if_error(users, 3, '', 'alice@example.com', 'password3')
-    assert result == 'No Username provided'
+    result = validate_account(users, 3, '', 'alice@example.com', 'password3')
+    assert result == [ValidationError('username', 'No Username provided')]
 
     # Test case 3: Existing username, expect 'Already such a User' error
-    result = check_if_error(users, 3, 'john', 'alice@example.com', 'password3')
-    assert result == 'Already such an User'
+    result = validate_account(users, 3, 'john', 'alice@example.com', 'password3')
+    assert result == [ValidationError('username', 'Already such an User')]
 
     # Test case 4: Empty email, expect 'No E-mail' error
-    result = check_if_error(users, 3, 'Alice', '', 'password3')
-    assert result == 'No E-mail provided'
+    result = validate_account(users, 3, 'Alice', '', 'password3')
+    assert result == [ValidationError('email', 'No E-mail provided')]
 
     # Test case 5: Existing email, expect 'Already such an E-mail' error
-    result = check_if_error(users, 3, 'Alice', 'john@example.com', 'password3')
-    assert result == 'Already such an E-mail'
+    result = validate_account(users, 3, 'Alice', 'john@example.com', 'password3')
+    assert result == [ValidationError('email', 'Already such an E-mail')]
 
     # Test case 6: Empty password, expect 'No password' error
-    result = check_if_error(users, 3, 'Alice', 'alice@example.com', '123')
-    assert result == 'Password must consist of at lest 8 characters'
+    result = validate_account(users, 3, 'Alice', 'alice@example.com', '123')
+    assert result == [ValidationError('password', 'Password must consist of at least 8 characters')]
 
     # Test case 7: Space in username, expect 'Username can not have spaces' error
-    result = check_if_error(users, 3, 'Ali ce', 'alice@example.com', 'password3')
-    assert result == 'Username can not have spaces'
+    result = validate_account(users, 3, 'Ali ce', 'alice@example.com', 'password3')
+    assert result == [ValidationError('username', 'Username can not have spaces')]
 
     # Test case 8: Space in password, expect 'Password can not have spaces' error
-    result = check_if_error(users, 3, 'Alice', 'alice@example.com', 'pass word3')
-    assert result == 'Password can not have spaces'
+    result = validate_account(users, 3, 'Alice', 'alice@example.com', 'pass word3')
+    assert result == [ValidationError('password', 'Password can not have spaces')]
 
 
 def test_get_product_by_url():

--- a/Cloth Shop Website/Web/tests/test_project.py
+++ b/Cloth Shop Website/Web/tests/test_project.py
@@ -15,7 +15,7 @@ from database import (
 from models import User, Product, Rating, Review
 import pytest
 from unittest.mock import patch
-from exceptions import ProductNotFound, UserNotFound
+from exceptions import DuplicateReview, ProductNotFound, UserNotFound
 from utils import (
     ValidationError,
     authenticate,
@@ -598,24 +598,75 @@ def test_create_account_errorr(mock_get_users, client):
 
     assert response.status_code == 200
 
-    
+
+LOGGED_IN_USER = {
+    'id': 1,
+    'name': 'john',
+    'email': 'john@example.com',
+    'surname': '',
+    'phone': '',
+    'country': '',
+    'city': '',
+}
 
 
+@patch('main.create_review')
+def test_save_review_reports_a_duplicate_as_a_conflict(mock_create_review, client):
+    mock_create_review.side_effect = DuplicateReview(1, 1)
+
+    with client.session_transaction() as flask_session:
+        flask_session['user'] = LOGGED_IN_USER
+
+    response = client.post('/save_review', json={'content': 'again', 'productId': 1})
+
+    assert response.status_code == 409
+    assert 'already reviewed' in response.get_json()['message']
 
 
+@patch('main.create_rating')
+def test_save_rating_reports_a_missing_product_as_not_found(mock_create_rating, client):
+    mock_create_rating.side_effect = ProductNotFound(99)
+
+    with client.session_transaction() as flask_session:
+        flask_session['user'] = LOGGED_IN_USER
+
+    response = client.post('/save_rating', json={'rating': 4, 'productId': 99})
+
+    assert response.status_code == 404
 
 
+@patch('main.get_users')
+def test_account_page_reports_every_invalid_field_at_once(mock_get_users, client):
+    mock_get_users.return_value = []
+
+    with client.session_transaction() as flask_session:
+        flask_session['user'] = LOGGED_IN_USER
+
+    response = client.post('/account', data={
+        'username': 'a b',
+        'email': '',
+        'password': '123',
+        'surname': '',
+        'phone': '',
+        'country': '',
+        'city': '',
+    })
+    body = response.get_data(as_text=True)
+
+    assert 'Username can not have spaces' in body
+    assert 'No E-mail provided' in body
+    assert 'at least 8 characters' in body
 
 
+@patch('main.get_users')
+def test_create_account_shows_the_password_error(mock_get_users, client):
+    mock_get_users.return_value = []
 
+    response = client.post('/create_account', data={
+        'username': 'alice',
+        'email': 'alice@example.com',
+        'password': '123',
+    })
 
-
-
-
-
-
-
-
-
-
-
+    assert response.status_code == 200
+    assert 'at least 8 characters' in response.get_data(as_text=True)

--- a/Cloth Shop Website/Web/utils.py
+++ b/Cloth Shop Website/Web/utils.py
@@ -1,4 +1,17 @@
-def filter_products(products, min_value, max_value, genders, kinds):
+from typing import Any, Iterable
+
+from models import User
+
+ProductDict = dict[str, Any]
+
+
+def filter_products(
+    products: list[ProductDict],
+    min_value: float,
+    max_value: float,
+    genders: list[str],
+    kinds: list[str],
+) -> list[ProductDict]:
     filtered_products = []
     for product in products:
         if product['cost'] > min_value and product['cost'] < max_value or max_value == 0:
@@ -7,7 +20,7 @@ def filter_products(products, min_value, max_value, genders, kinds):
                     filtered_products.append(product)
     return filtered_products
 
-def check_login(username, password, users):
+def check_login(username: str, password: str, users: list[User]) -> tuple[str, User | None]:
     for user in users:
         if user.name == username:  
             if user.check_password(password): 
@@ -17,7 +30,13 @@ def check_login(username, password, users):
     else:
         return 'Wrong Username', None
     
-def check_if_error(users, id, username, email, password):
+def check_if_error(
+    users: list[User],
+    id: int | None,
+    username: str,
+    email: str,
+    password: str,
+) -> str | None:
     if ' ' in username:
         return 'Username can not have spaces'
     if ' ' in password:
@@ -39,13 +58,13 @@ def check_if_error(users, id, username, email, password):
     else:
         return 'No Username provided'
     
-def get_product_by_url(products, product_url):
+def get_product_by_url(products: list[ProductDict], product_url: str) -> ProductDict | None:
     for product in products:
         if product['url'] == product_url:
             return product
     return None
 
-def get_genders_and_kinds(request):
+def get_genders_and_kinds(request: Iterable[str]) -> tuple[list[str], list[str]]:
     genders = []
     kinds = []
     if 'male' in request:
@@ -63,7 +82,7 @@ def get_genders_and_kinds(request):
 
 
 
-def get_username_by_id_filter(users, user_id):
+def get_username_by_id_filter(users: list[User], user_id: int) -> str:
     for user in users:
         if user.id == user_id:
             return user.name

--- a/Cloth Shop Website/Web/utils.py
+++ b/Cloth Shop Website/Web/utils.py
@@ -1,8 +1,17 @@
+from dataclasses import dataclass
 from typing import Any, Iterable
 
 from models import User
 
 ProductDict = dict[str, Any]
+
+MINIMUM_PASSWORD_LENGTH = 8
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    field: str
+    message: str
 
 
 def filter_products(
@@ -20,44 +29,52 @@ def filter_products(
                     filtered_products.append(product)
     return filtered_products
 
-def check_login(username: str, password: str, users: list[User]) -> tuple[str, User | None]:
+def authenticate(
+    username: str,
+    password: str,
+    users: list[User],
+) -> tuple[User | None, ValidationError | None]:
     for user in users:
-        if user.name == username:  
-            if user.check_password(password): 
-                return 'good', user
-            else:
-                return 'Wrong Password', None
-    else:
-        return 'Wrong Username', None
+        if user.name == username:
+            if user.check_password(password):
+                return user, None
+            return None, ValidationError('password', 'Wrong Password')
+    return None, ValidationError('username', 'Wrong Username')
     
-def check_if_error(
+def validate_account(
     users: list[User],
     id: int | None,
     username: str,
     email: str,
     password: str,
-) -> str | None:
-    if ' ' in username:
-        return 'Username can not have spaces'
+) -> list[ValidationError]:
+    errors = []
+
+    if username == '':
+        errors.append(ValidationError('username', 'No Username provided'))
+    elif ' ' in username:
+        errors.append(ValidationError('username', 'Username can not have spaces'))
+    elif any(user.name == username and user.id != id for user in users):
+        errors.append(ValidationError('username', 'Already such an User'))
+
+    if email == '':
+        errors.append(ValidationError('email', 'No E-mail provided'))
+    elif any(user.email == email and user.id != id for user in users):
+        errors.append(ValidationError('email', 'Already such an E-mail'))
+
     if ' ' in password:
-        return 'Password can not have spaces'
-    if username != '':
-        if email != '':
-            if all(user.name != username or user.id == id for user in users):
-                if all(user.email != email or user.id == id for user in users):
-                    if len(password) < 8:
-                        return 'Password must consist of at lest 8 characters'
-                    else:
-                        return None
-                else:
-                    return 'Already such an E-mail'
-            else:
-                return 'Already such an User'
-        else:
-            return 'No E-mail provided'
-    else:
-        return 'No Username provided'
-    
+        errors.append(ValidationError('password', 'Password can not have spaces'))
+    elif len(password) < MINIMUM_PASSWORD_LENGTH:
+        errors.append(
+            ValidationError(
+                'password',
+                f'Password must consist of at least {MINIMUM_PASSWORD_LENGTH} characters',
+            )
+        )
+
+    return errors
+
+
 def get_product_by_url(products: list[ProductDict], product_url: str) -> ProductDict | None:
     for product in products:
         if product['url'] == product_url:

--- a/Cloth Shop Website/scripts/migrate_passwords.py
+++ b/Cloth Shop Website/scripts/migrate_passwords.py
@@ -20,11 +20,11 @@ DEFAULT_DB = "Databases/mydb.db"
 KNOWN_HASH_PREFIXES = ("pbkdf2:", "scrypt:", "argon2")
 
 
-def looks_hashed(value):
+def looks_hashed(value: str | None) -> bool:
     return bool(value) and value.startswith(KNOWN_HASH_PREFIXES)
 
 
-def migrate(db_path):
+def migrate(db_path: str) -> None:
     connection = sqlite3.connect(db_path)
     try:
         rows = connection.execute("SELECT id, name, password FROM accounts").fetchall()


### PR DESCRIPTION
Makes the codebase state its own contracts: what each function takes, what it returns, and how it reports failure. Reviewing commit by commit is easiest — each one is a single concern.

## What changed

**`ba6ccb7` Type hints across the application modules.** Every function in `Web/` and the migration script now declares its parameters and return type. The `SessionFactory` alias names the thing that every `database.py` function threads through: the parameter called `Session` is a `sessionmaker`, not a session.

**`2e35589` Every database session opens through `session_scope`.** The read and delete helpers each opened a session and closed it only on the happy path, so any query that raised leaked the connection and left its transaction open. `session_scope` already existed and was used in two places; now it is used everywhere. `update_user` also opened a session before looking up the user and returned without closing it when the id matched nobody.

**`d85759c` Failure is signalled by layer instead of by sentinel value.** The data layer returned `None`, `False` or a prose string depending on which function failed, and validation returned `None` to mean *success* — the opposite of everywhere else.

- `database.py` raises `DuplicateUser`, `DuplicateReview`, `ProductNotFound`, `UserNotFound`, each carrying the identifiers that failed. The create helpers now return their object unconditionally: `create_review` went from `Review | None | bool` to `Review`.
- Validation returns `list[ValidationError]`. An empty list means accepted, the list reports every problem at once instead of only the first, and each entry names its field.
- Routes translate exceptions through error handlers registered once, rather than inspecting return values at each call site.

**`d381d96` Tests for the failure contract.** The suite was green through the change without exercising it.

## Behaviour changes to be aware of

- **`save_review` answers a duplicate with 409**, not `200 OK` carrying `{'message': 'error'}`. Missing records answer 404.
- **`update_user` raises `UserNotFound`** where it used to silently do nothing. No route currently reaches that path; `test_update_user` now asserts the raise.
- **`check_if_error` → `validate_account`, `check_login` → `authenticate`.** Both old names described the old contract.
- **One user-visible string**: "at lest 8 characters" → "at least 8 characters", with the 8 lifted into `MINIMUM_PASSWORD_LENGTH`.

## A bug this fixed

The templates chose which input to flag by substring-matching the error prose — `{% if error and 'E-mail' in error %}`. They now select on `errors.username` / `.email` / `.password`.

`create_account.html` tested for lowercase `'password'`, but every password message begins with a capital P, so **password errors never displayed on the signup form**. There is now a test for it.

Forms also report every problem at once; previously you fixed one, resubmitted, and learned about the next.

## Verification

- 53 tests pass (49 before, 4 added).
- The two new tests covering changed behaviour were mutation-checked: flipping the 409 to a 200 and breaking the template lookup makes them fail.
- `/account` and `/login` error rendering was also exercised by hand, since the suite previously never rendered those pages.

## Known issues left alone

Both were surfaced by the type hints and are pre-existing, so they are not touched here:

- `main.py` `product_detail` dereferences `product_dict` without a `None` guard inside the `if 'user' in session` branch, so a **logged-in** user visiting an unknown product URL gets a 500 instead of the not-found page.
- `logout()` returns `None` when nobody is logged in, which Flask rejects.

`models.py` still uses the pre-2.0 SQLAlchemy mapping style, so mypy cannot check it usefully until it migrates to `Mapped[...] = mapped_column(...)`. That accounts for roughly 40 of the remaining checker errors and blocks putting mypy in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
